### PR TITLE
LOAPI-24: Supporting XML type

### DIFF
--- a/pso-flint-berlioz/src/main/java/org/pageseeder/flint/berlioz/model/FlintConfig.java
+++ b/pso-flint-berlioz/src/main/java/org/pageseeder/flint/berlioz/model/FlintConfig.java
@@ -85,7 +85,7 @@ public class FlintConfig {
   private static ContentTranslatorFactory TRANSLATORS = new ContentTranslatorFactory() {
 
     public ContentTranslator createTranslator(String mimeType) {
-      if ("psml".equals(mimeType))
+      if ("psml".equals(mimeType) || "xml".equals(mimeType) )
         return new SourceForwarder(mimeType, "UTF-8");
       return null;
     }
@@ -93,7 +93,7 @@ public class FlintConfig {
     public Collection<String> getMimeTypesSupported() {
       ArrayList<String> mimes = new ArrayList<String>();
       mimes.add("psml");
-      // mimes.add("xml");
+      mimes.add("xml");
       return mimes;
     }
   };

--- a/src/main/java/org/pageseeder/flint/indexing/IndexingThread.java
+++ b/src/main/java/org/pageseeder/flint/indexing/IndexingThread.java
@@ -273,6 +273,10 @@ public final class IndexingThread implements Runnable {
     }
     if (source == null)
       throw new IndexException("Failed to translate Content as the Translator returned a null result.", null);
+    
+    if("xml".equals(mediatype))
+    	mediatype="psml";
+    
     // retrieve XSLT script
     Templates templates = index.getTemplates(content.getContentType(), mediatype);
     if (templates == null)


### PR DESCRIPTION
Hi JB,

In API 1, we were able to add "XML" files to the index(we were inserting legisaltion-events.xml file to the index). When we were trying to
do same thing with API 3, Flint complain as "Media Type xml is not supported, no Translator Factory was found and no default Translator was specified".
Therefore we got to change following flow changes.

Thanks,
Upul